### PR TITLE
simpler way to add explicit_set_keys

### DIFF
--- a/lib/spark/dsl/entity.ex
+++ b/lib/spark/dsl/entity.ex
@@ -107,13 +107,14 @@ defmodule Spark.Dsl.Entity do
       ) do
     {before_validate_auto, after_validate_auto} =
       Keyword.split(auto_set_fields || [], Keyword.keys(schema))
-
+    meta = %{explicit_set_keys: Keyword.keys(opts)}
     with {:ok, opts} <-
            OptionsHelpers.validate(Keyword.merge(opts || [], before_validate_auto), schema),
          opts <- Keyword.merge(opts, after_validate_auto),
          opts <- Enum.map(opts, fn {key, value} -> {schema[key][:as] || key, value} end),
          built <- struct(target, opts),
          built <- struct(built, nested_entities),
+         built <- Map.put(built, :__spark_meta__, meta),
          {:ok, built} <- transform(transform, built) do
       case identifier do
         nil ->

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -1618,7 +1618,7 @@ defmodule Spark.Dsl.Extension do
                     built =
                       case Entity.build(unquote(Macro.escape(entity)), opts, nested_entities) do
                         {:ok, built} ->
-                          built |> put_in([:__spark_meta__][:entity_name], entity_name)
+                          built |> put_in([:__spark_meta__, :entity_name], entity_name)
 
                         {:error, error} ->
                           additional_path =

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -1618,7 +1618,7 @@ defmodule Spark.Dsl.Extension do
                     built =
                       case Entity.build(unquote(Macro.escape(entity)), opts, nested_entities) do
                         {:ok, built} ->
-                          built
+                          built |> put_in([:__spark_meta__][:entity_name], entity_name)
 
                         {:error, error} ->
                           additional_path =


### PR DESCRIPTION
another option would be to tack on a dedicated `:__spark_meta__` field (or whatever you want to call it) similar to Ecto's `:__meta__` field, I'm not familiar enough to know what all would be useful but I could also see the schema and identifier having a home in `:__spark_meta__` as well. Maybe there is other info in the Extension module that would be relevant during the transform as well?